### PR TITLE
github  build action implemented and .tarvis.yml removed

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,39 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: python-build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: python
-python:
-  - "3.9"
-install:
-  - pip install -r requirements.txt
-scripts:
-  - pytest


### PR DESCRIPTION
you can add a badge to the readme files with "[![python-build](https://github.com/vishalveerareddy/CSC_510-Team-31_HW1/actions/workflows/python-app.yml/badge.svg)](https://github.com/vishalveerareddy/CSC_510-Team-31_HW1/actions/workflows/python-app.yml)" I couldn't do it in the fork